### PR TITLE
add api.export for meteor 0.6.5

### DIFF
--- a/package.js
+++ b/package.js
@@ -3,7 +3,6 @@ Package.describe({
 });
 
 Package.on_use(function (api) {
-  api.add_files([
-    'loadpicker.js'
-  ],'client');
+  api.add_files(['loadpicker.js'],'client');
+  api.export('loadPicker', 'client');
 });


### PR DESCRIPTION
with this fix you can use loadpicker again in Meteor 0.6.5
